### PR TITLE
Handle the frame_max option when negotiating the connection with the server

### DIFF
--- a/lib/carrot/amqp/server.rb
+++ b/lib/carrot/amqp/server.rb
@@ -26,6 +26,7 @@ module Carrot::AMQP
       @user   = opts[:user]  || 'guest'
       @pass   = opts[:pass]  || 'guest'
       @vhost  = opts[:vhost] || '/'
+      @frame_max = opts[:frame_max] || 131072
       @insist = opts[:insist]
       @status = 'NOT CONNECTED'
 
@@ -166,7 +167,7 @@ module Carrot::AMQP
 
       if method.is_a?(Protocol::Connection::Tune)
         send_frame(
-          Protocol::Connection::TuneOk.new( :channel_max => 0, :frame_max => 131072, :heartbeat => 0)
+          Protocol::Connection::TuneOk.new( :channel_max => 0, :frame_max => @frame_max, :heartbeat => 0)
         )
       end
 


### PR DESCRIPTION
The `:frame_max` option passed to Carrot is ignored when negotiating the connection with the server and Carrot is simply using 131072 as the hardcoded value. This was not a problem with RabbitMQ 2.x because it was not handling the frame_max. But in RabbitMQ 3.x, frame_max is honored and if the client passes 131072, the server will enforce this value and prevent any frame larger than this from being sent.

This patch makes sure that the `:frame_max` value passes in the option is used during the negotiation and will consequently allow creating messages larger than 131072 bytes in RabbitMQ 3.x.
